### PR TITLE
Allow for PayPal entry

### DIFF
--- a/app/resources/js/index.js
+++ b/app/resources/js/index.js
@@ -47611,12 +47611,14 @@ to {
   var specialCommands = {
     $gw2_account$: /(^|\s)\w+\.\d{4}($|\s)/,
     $steam_friend$: /(^|\s)\d{8}($|\s)/,
-    $gw2_or_steam$: /(^|\s)\w+\.\d{4}($|\s)|(^|\s)\d{8}($|\s)/
+    $gw2_or_steam$: /(^|\s)(\w+\.\d{4}|\d{8})($|\s)/,
+    $gw2_steam_paypal$: /(^|\s)(\w+\.\d{4}|\d{8}|paypal)($|\s)/
   };
   var specialCommandsForCombination = {
     $gw2_account$: "\\w+\\.\\d{4}",
     $steam_friend$: "\\d{8}",
-    $gw2_or_steam$: "\\w+\\.\\d{4}|\\d{8}"
+    $gw2_or_steam$: "\\w+\\.\\d{4}|\\d{8}",
+    $gw2_steam_paypal$: "\\w+\\.\\d{4}|\\d{8}|paypal"
   };
   function escapeRegExp(text) {
     return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");

--- a/app/src/utils/misc.ts
+++ b/app/src/utils/misc.ts
@@ -25,13 +25,15 @@ export function chunkArray<T>(arr: T[], chunkSize: number): T[][] {
 const specialCommands = {
   $gw2_account$: /(^|\s)\w+\.\d{4}($|\s)/,
   $steam_friend$: /(^|\s)\d{8}($|\s)/,
-  $gw2_or_steam$: /(^|\s)\w+\.\d{4}($|\s)|(^|\s)\d{8}($|\s)/,
+  $gw2_or_steam$: /(^|\s)(\w+\.\d{4}|\d{8})($|\s)/,
+  $gw2_steam_paypal$: /(^|\s)(\w+\.\d{4}|\d{8}|paypal)($|\s)/
 }
 
 const specialCommandsForCombination = {
   $gw2_account$: '\\w+\\.\\d{4}',
   $steam_friend$: '\\d{8}',
   $gw2_or_steam$: '\\w+\\.\\d{4}|\\d{8}',
+  $gw2_steam_paypal$: '\\w+\\.\\d{4}|\\d{8}|paypal'
 }
 
 function escapeRegExp(text) {


### PR DESCRIPTION
added special command `$gw2_steam_paypal$` to allow for either GW2 IGN, Steam friend code, or the word "PayPal" to allow payment via PayPal (account to be sent via DM).  This was in response to Mukluk's giveaway on 10/13/2022